### PR TITLE
メッセージのCRUD処理実装

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,2 @@
+class MessagesController < ApplicationController
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,5 +1,10 @@
 class MessagesController < ApplicationController
 
+  # indexアクション
+  def index
+    @messages = Message.all
+  end
+
   # newアクション
   def new
     @message = Message.new

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -20,6 +20,17 @@ class MessagesController < ApplicationController
     @message = Message.find(params[:id])
   end
 
+  # editアクション
+  def edit
+    @message = Message.find(params[:id])
+  end
+
+  # updateアクション
+  def update
+    message = Message.find(params[:id])
+    message.update(message_params)
+  end
+
   private
 
   def message_params

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,2 +1,18 @@
 class MessagesController < ApplicationController
+
+  # newアクション
+  def new
+    @message = Message.new
+  end
+
+  # createアクション
+  def create
+    Message.create(message_params)
+  end
+
+  private
+
+  def message_params
+    params.require(:message).permit(:title, :contents)
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -15,6 +15,11 @@ class MessagesController < ApplicationController
     Message.create(message_params)
   end
 
+  # showアクション
+  def show
+    @message = Message.find(params[:id])
+  end
+
   private
 
   def message_params

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -31,6 +31,12 @@ class MessagesController < ApplicationController
     message.update(message_params)
   end
 
+  # destroyアクション
+  def destroy
+    message = Message.find(params[:id])
+    message.destroy
+  end
+
   private
 
   def message_params

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,2 @@
+class Message < ApplicationRecord
+end

--- a/app/views/messages/create.html.erb
+++ b/app/views/messages/create.html.erb
@@ -1,0 +1,2 @@
+<h1>投稿完了</h1>
+<%= link_to "一覧画面へ", messages_path %>

--- a/app/views/messages/destroy.html.erb
+++ b/app/views/messages/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>削除完了</h1>
+<%= link_to "一覧画面へ", messages_path %>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,0 +1,7 @@
+<h1>メッセージ 編集</h1>
+<%= form_with model: @message, local: true do |f| %>
+  <p>タイトル: <%= f.text_field :title %></p>
+  <p>内容: <%= f.text_field :contents %></p>
+  <p><%= f.submit "送信" %></p>
+  <%= link_to "一覧画面へ", messages_path %>
+<% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -4,5 +4,6 @@
   <p>
     <%= message.title %>
     <%= link_to "詳細", message_path(message.id) %>
+    <%= link_to "編集", edit_message_path(message.id) %>
   </p>
 <% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -5,5 +5,6 @@
     <%= message.title %>
     <%= link_to "詳細", message_path(message.id) %>
     <%= link_to "編集", edit_message_path(message.id) %>
+    <%= link_to "削除", message_path(message.id), method: :delete, data: {confirm: "削除しますか？"} %>
   </p>
 <% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,0 +1,5 @@
+<h1>メッセージ一覧</h1>
+<%= link_to "投稿画面へ", new_message_path %>
+<% @messages.each do |message| %>
+  <p><%= message.title %></p>
+<% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,5 +1,8 @@
-<h1>メッセージ一覧</h1>
+<h1>メッセージ 一覧</h1>
 <%= link_to "投稿画面へ", new_message_path %>
 <% @messages.each do |message| %>
-  <p><%= message.title %></p>
+  <p>
+    <%= message.title %>
+    <%= link_to "詳細", message_path(message.id) %>
+  </p>
 <% end %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,0 +1,7 @@
+<h1>メッセージ 作成</h1>
+<%= form_with model: @message, local: true do |f| %>
+  <p>タイトル:<%= f.text_field :title %></p>
+  <p>内容:<%= f.text_field :contents %></p>
+  <p><%= f.submit "送信" %></p>
+  <%= link_to "一覧画面へ", messages_path %>
+<% end %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -1,7 +1,7 @@
 <h1>メッセージ 作成</h1>
 <%= form_with model: @message, local: true do |f| %>
-  <p>タイトル:<%= f.text_field :title %></p>
-  <p>内容:<%= f.text_field :contents %></p>
+  <p>タイトル: <%= f.text_field :title %></p>
+  <p>内容: <%= f.text_field :contents %></p>
   <p><%= f.submit "送信" %></p>
   <%= link_to "一覧画面へ", messages_path %>
 <% end %>

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,0 +1,4 @@
+<h1>メッセージ 詳細</h1>
+<p>タイトル: <%= @message.title %></p>
+<p>内容: <%= @message.contents %></p>
+<%= link_to "一覧画面へ", messages_path %>

--- a/app/views/messages/update.html.erb
+++ b/app/views/messages/update.html.erb
@@ -1,0 +1,2 @@
+<h1>更新完了</h1>
+<%= link_to "一覧画面へ", messages_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :messages
 end

--- a/db/migrate/20210510211256_create_messages.rb
+++ b/db/migrate/20210510211256_create_messages.rb
@@ -1,0 +1,9 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.string :title
+      t.string :contents
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2021_05_10_211256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "messages", force: :cascade do |t|
+    t.string "title"
+    t.string "contents"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end


### PR DESCRIPTION
## 実装内容

【補足】原則，以下のようなマークダウン記法のリストで記載すること

- 「メッセージ」の CRUD 処理を実装
  - 一覧表示機能
  - 新規投稿機能
  - 詳細表示機能
  - 編集機能
  - 削除機能

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考

commitは7回実施